### PR TITLE
Don't display "Displaying icons" message in echo area

### DIFF
--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -50,7 +50,6 @@
   "Display the icons of files in a dired buffer."
   (when (and (not all-the-icons-dired-displayed) dired-subdir-alist)
     (setq-local all-the-icons-dired-displayed t)
-    (message "Displaying icons")
     (let ((inhibit-read-only t)
 	  (remote-p (tramp-tramp-file-p default-directory)))
       (save-excursion


### PR DESCRIPTION
If dired buffers are open, even if one is not dealing with them - the message
"Displaying icons" keeps popping up in echo area which is annoying.