### PR TITLE
Check for Tramp before using it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # Packaging
 .cask
+
+# Emacs temp-files
+*~
+*#*

--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -52,7 +52,8 @@
   (when (and (not all-the-icons-dired-displayed) dired-subdir-alist)
     (setq-local all-the-icons-dired-displayed t)
     (let ((inhibit-read-only t)
-	  (remote-p (tramp-tramp-file-p default-directory)))
+	  (remote-p (and (fboundp 'tramp-tramp-file-p)
+                         (tramp-tramp-file-p default-directory))))
       (save-excursion
 	(goto-char (point-min))
 	(while (not (eobp))

--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -4,7 +4,7 @@
 
 ;; Author: jtbm37
 ;; Version: 1.0
-;; Keywords: icons, dired
+;; Keywords: files icons dired
 ;; Package-Requires: ((emacs "24.4") (all-the-icons "2.2.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -77,7 +77,7 @@
 	  (forward-line 1))))))
 
 (defun all-the-icons-dired--reset (&optional _arg _noconfirm)
-  "Functions used as advice when redisplaying buffer"
+  "Functions used as advice when redisplaying buffer."
   (setq-local all-the-icons-dired-displayed nil))
 
 ;;;###autoload


### PR DESCRIPTION
Check that `tramp-tramp-file-p` actually is bound before using it.

Also:
- Ignore Emacs temp-files
- Fix package-lint- and checkdoc errors