### PR TITLE
Support a buffer with missing file-name

### DIFF
--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -60,21 +60,22 @@
 	  (when (dired-move-to-filename nil)
 	    (let ((file (dired-get-filename 'verbatim t)))
 	      (unless (member file '("." ".."))
-		(let ((filename (dired-get-filename nil t)))
-		  (if (file-directory-p filename)
-		      (let* ((matcher (all-the-icons-match-to-alist file all-the-icons-dir-icon-alist))
-			     (icon (cond
-				    (remote-p
-				     (all-the-icons-octicon "file-directory" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
-				    ((file-symlink-p filename)
-				     (all-the-icons-octicon "file-symlink-directory" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
-				    ((all-the-icons-dir-is-submodule filename)
-				     (all-the-icons-octicon "file-submodule" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
-				    ((file-exists-p (format "%s/.git" filename))
-				     (all-the-icons-octicon "repo" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
-				    (t (apply (car matcher) (list (cadr matcher) :face 'all-the-icons-dired-dir-face :v-adjust all-the-icons-dired-v-adjust))))))
-			(insert (concat icon " ")))
-		    (insert (concat (all-the-icons-icon-for-file file :v-adjust all-the-icons-dired-v-adjust) " ")))))))
+                (let ((filename (dired-get-filename nil t)))
+                  (when filename
+                    (if (file-directory-p filename)
+                        (let* ((matcher (all-the-icons-match-to-alist file all-the-icons-dir-icon-alist))
+                               (icon (cond
+                                      (remote-p
+                                       (all-the-icons-octicon "file-directory" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
+                                      ((file-symlink-p filename)
+                                       (all-the-icons-octicon "file-symlink-directory" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
+                                      ((all-the-icons-dir-is-submodule filename)
+                                       (all-the-icons-octicon "file-submodule" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
+                                      ((file-exists-p (format "%s/.git" filename))
+                                       (all-the-icons-octicon "repo" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
+                                      (t (apply (car matcher) (list (cadr matcher) :face 'all-the-icons-dired-dir-face :v-adjust all-the-icons-dired-v-adjust))))))
+                          (insert (concat icon " ")))
+                      (insert (concat (all-the-icons-icon-for-file file :v-adjust all-the-icons-dired-v-adjust) " "))))))))
 	  (forward-line 1))))))
 
 (defun all-the-icons-dired--reset (&optional _arg _noconfirm)


### PR DESCRIPTION
This is caused by a transient state when deleting files with `wdired`.

As mentioned in #18 this doesn't work well together with `wdired-mode`. I have managed to get it working by doing the following:

```elisp
(defvar-local +wdired-icons-enabled nil)
(defun +wdired-before-start-advice ()
  "Execute when switching from `dired' to `wdired'."
  (setq +wdired-icons-enabled (if (bound-and-true-p all-the-icons-dired-mode)
                                  1 0))
  (when (bound-and-true-p all-the-icons-dired-mode)
    (all-the-icons-dired-mode 0)))
(defun +wdired-after-finish-advice ()
  "Execute when switching from `wdired' to `dired'"
  (when (boundp 'all-the-icons-dired-mode)
    (all-the-icons-dired-mode +wdired-icons-enabled)))
(advice-add 'wdired-change-to-wdired-mode :before #'+wdired-before-start-advice)
(advice-add 'wdired-change-to-dired-mode :after #'+wdired-after-finish-advice)
```

That works for renaming files, etc. But when deleting a file you end up in a state while
the file-name is blank for a while (that is how you remove files). With this safeguard to
skip actions when there is no filename we won't run into any nil errors.