### PR TITLE
refactor code base and add custom icon args options.

### DIFF
--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -47,8 +47,13 @@
 (defvar-local all-the-icons-dired-displayed nil
   "Flags whether icons have been added.")
 
+(defcustom all-the-icons-dired-icon-args nil
+  "Initial list of arguments passed to all-the-icons icon functions."
+  :group 'all-the-icons
+  :type 'sexp)
+
 (defun all-the-icons-dired--icon-for-filename (file filename &optional remote-p)
-  (let ((icon-args `(:v-adjust ,all-the-icons-dired-v-adjust))
+  (let ((icon-args `(,@all-the-icons-dired-icon-args :v-adjust ,all-the-icons-dired-v-adjust))
         icon-func icon-name)
     (if (file-directory-p filename)
         (progn

--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -47,35 +47,40 @@
 (defvar-local all-the-icons-dired-displayed nil
   "Flags whether icons have been added.")
 
+(defun all-the-icons-dired--icon-for-filename (file filename &optional remote-p)
+  (if (file-directory-p filename)
+      (let* ((matcher (all-the-icons-match-to-alist file all-the-icons-dir-icon-alist))
+             (icon (cond
+                    (remote-p
+                     (all-the-icons-octicon "file-directory" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
+                    ((file-symlink-p filename)
+                     (all-the-icons-octicon "file-symlink-directory" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
+                    ((all-the-icons-dir-is-submodule filename)
+                     (all-the-icons-octicon "file-submodule" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
+                    ((file-exists-p (format "%s/.git" filename))
+                     (all-the-icons-octicon "repo" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
+                    (t (apply (car matcher) (list (cadr matcher) :face 'all-the-icons-dired-dir-face :v-adjust all-the-icons-dired-v-adjust))))))
+        (insert (concat icon " ")))
+    (insert (concat (all-the-icons-icon-for-file file :v-adjust all-the-icons-dired-v-adjust) " ")))
+  )
+
 (defun all-the-icons-dired--display ()
   "Display the icons of files in a dired buffer."
   (when (and (not all-the-icons-dired-displayed) dired-subdir-alist)
     (setq-local all-the-icons-dired-displayed t)
     (let ((inhibit-read-only t)
-	  (remote-p (and (fboundp 'tramp-tramp-file-p)
+	        (remote-p (and (fboundp 'tramp-tramp-file-p)
                          (tramp-tramp-file-p default-directory))))
       (save-excursion
-	(goto-char (point-min))
-	(while (not (eobp))
-	  (when (dired-move-to-filename nil)
-	    (let ((file (dired-get-filename 'verbatim t)))
-	      (unless (member file '("." ".."))
-		(let ((filename (dired-get-filename nil t)))
-		  (if (file-directory-p filename)
-		      (let* ((matcher (all-the-icons-match-to-alist file all-the-icons-dir-icon-alist))
-			     (icon (cond
-				    (remote-p
-				     (all-the-icons-octicon "file-directory" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
-				    ((file-symlink-p filename)
-				     (all-the-icons-octicon "file-symlink-directory" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
-				    ((all-the-icons-dir-is-submodule filename)
-				     (all-the-icons-octicon "file-submodule" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
-				    ((file-exists-p (format "%s/.git" filename))
-				     (all-the-icons-octicon "repo" :v-adjust all-the-icons-dired-v-adjust :face 'all-the-icons-dired-dir-face))
-				    (t (apply (car matcher) (list (cadr matcher) :face 'all-the-icons-dired-dir-face :v-adjust all-the-icons-dired-v-adjust))))))
-			(insert (concat icon " ")))
-		    (insert (concat (all-the-icons-icon-for-file file :v-adjust all-the-icons-dired-v-adjust) " ")))))))
-	  (forward-line 1))))))
+	      (goto-char (point-min))
+	      (while (not (eobp))
+	        (when (dired-move-to-filename nil)
+	          (let ((file (dired-get-filename 'verbatim t)))
+	            (unless (member file '("." ".."))
+		            (let ((filename (dired-get-filename nil t)))
+                  (all-the-icons-dired--icon-for-filename file filename remote-p)
+		              ))))
+	        (forward-line 1))))))
 
 (defun all-the-icons-dired--reset (&optional _arg _noconfirm)
   "Functions used as advice when redisplaying buffer."


### PR DESCRIPTION
I've seperated icon-selection from icon-insertion, removed a lot of the repetitive configurations arguments in the calls to the `all-the-icon-*` functions, and added a new option `all-the-icons-dired-icon-args` allowing users to specify the arguments they want to pass to all-the-icons.

This initially started off just because I wanted to specify the height of the icons, but to do so I'd have to edit 5 different locations. Now I just need to customise one variable.

I've also inadvertently reindented the code base, because evil-return auto indents to the recommended indent specifications; I also found this new indentation scheme more readable so I hope this won't be an issue. If there was some logical reason for the old approach, I'm open to reverting it (as best I can).