### PR TITLE
Speed up refresh and prevent line move from signaling

### DIFF
--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -79,15 +79,16 @@
   (save-excursion
     (goto-char (point-min))
     (while (not (eobp))
-      (let ((file (dired-get-filename 'relative 'noerror)))
-        (when file
-          (let ((icon (if (file-directory-p file)
-                          (all-the-icons-icon-for-dir file nil "")
-                        (all-the-icons-icon-for-file file :v-adjust all-the-icons-dired-v-adjust))))
-            (if (member file '("." ".."))
-                (all-the-icons-dired--add-overlay (point) "  \t")
-              (all-the-icons-dired--add-overlay (point) (concat icon "\t"))))))
-      (dired-next-line 1))))
+      (when (dired-move-to-filename nil)
+        (let ((file (dired-get-filename 'relative 'noerror)))
+          (when file
+            (let ((icon (if (file-directory-p file)
+                            (all-the-icons-icon-for-dir file nil "")
+                          (all-the-icons-icon-for-file file :v-adjust all-the-icons-dired-v-adjust))))
+              (if (member file '("." ".."))
+                  (all-the-icons-dired--add-overlay (point) "  \t")
+                (all-the-icons-dired--add-overlay (point) (concat icon "\t")))))))
+      (forward-line 1))))
 
 (defun all-the-icons-dired--refresh-advice (fn &rest args)
   "Advice function for FN with ARGS."


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/jtbm37/all-the-icons-dired/pull/24#issuecomment-593201966)

Explanation:

`dired-next-line` moves character by character, and its calls to `line-move-*` signal errors, which stops timer functions from executing silently. This PR fixes both issues.

CC @conao3 