### PR TITLE
make icons use same color as the text

### DIFF
--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -47,6 +47,11 @@
   :group 'all-the-icons
   :type 'number)
 
+(defcustom all-the-icons-dired-monochrome t
+  "Whether to show the icons as the same color as the text on the same line."
+  :group 'all-the-icons
+  :type 'boolean)
+
 (defvar all-the-icons-dired-mode)
 
 (defun all-the-icons-dired--add-overlay (pos string)
@@ -86,7 +91,11 @@
                             (all-the-icons-icon-for-dir file
                                                         :face 'all-the-icons-dired-dir-face
                                                         :v-adjust all-the-icons-dired-v-adjust)
-                          (all-the-icons-icon-for-file file :v-adjust all-the-icons-dired-v-adjust))))
+                          (apply 'all-the-icons-icon-for-file file
+                                 (append
+                                  `(:v-adjust ,all-the-icons-dired-v-adjust)
+                                  (when all-the-icons-dired-monochrome
+                                    `(:face ,(face-at-point))))))))
               (if (member file '("." ".."))
                   (all-the-icons-dired--add-overlay (point) "  \t")
                 (all-the-icons-dired--add-overlay (point) (concat icon "\t")))))))


### PR DESCRIPTION
The icons from all-the-icons by default come in all kinds of colors, but dired also have faces defined for the directory entries. This make the dired buffer very busy and distracting. This PR keeps the icon colors the same as the text by default, with the option to revert back to current behavior.

Before:
<img width="216" alt="Screen Shot 2020-04-03 at 22 23 48" src="https://user-images.githubusercontent.com/160028/78406126-dfc8b280-75f9-11ea-8704-0adbe065a28a.png">

After:
<img width="216" alt="Screen Shot 2020-04-03 at 22 23 15" src="https://user-images.githubusercontent.com/160028/78406110-d6d7e100-75f9-11ea-84d8-089dbe9c1f3b.png">
