### PR TITLE
Update icons after directory creation and rename

### DIFF
--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -108,6 +108,7 @@
     (advice-add 'dired-insert-subdir :around #'all-the-icons-dired--refresh-advice)
     (advice-add 'dired-do-kill-lines :around #'all-the-icons-dired--refresh-advice)
     (advice-add 'dired-create-directory :around #'all-the-icons-dired--refresh-advice)
+    (advice-add 'dired-do-rename :around #'all-the-icons-dired--refresh-advice)
     (with-eval-after-load 'dired-narrow
       (advice-add 'dired-narrow--internal :around #'all-the-icons-dired--refresh-advice))
     (all-the-icons-dired--refresh)))
@@ -121,6 +122,7 @@
   (advice-remove 'dired-insert-subdir #'all-the-icons-dired--refresh-advice)
   (advice-remove 'dired-do-kill-lines #'all-the-icons-dired--refresh-advice)
   (advice-remove 'dired-create-directory #'all-the-icons-dired--refresh-advice)
+  (advice-remove 'dired-do-rename #'all-the-icons-dired--refresh-advice)
   (all-the-icons-dired--remove-all-overlays))
 
 ;;;###autoload

--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -107,6 +107,7 @@
     (advice-add 'dired-internal-do-deletions :around #'all-the-icons-dired--refresh-advice)
     (advice-add 'dired-insert-subdir :around #'all-the-icons-dired--refresh-advice)
     (advice-add 'dired-do-kill-lines :around #'all-the-icons-dired--refresh-advice)
+    (advice-add 'dired-create-directory :around #'all-the-icons-dired--refresh-advice)
     (with-eval-after-load 'dired-narrow
       (advice-add 'dired-narrow--internal :around #'all-the-icons-dired--refresh-advice))
     (all-the-icons-dired--refresh)))
@@ -119,6 +120,7 @@
   (advice-remove 'dired-narrow--internal #'all-the-icons-dired--refresh-advice)
   (advice-remove 'dired-insert-subdir #'all-the-icons-dired--refresh-advice)
   (advice-remove 'dired-do-kill-lines #'all-the-icons-dired--refresh-advice)
+  (advice-remove 'dired-create-directory #'all-the-icons-dired--refresh-advice)
   (all-the-icons-dired--remove-all-overlays))
 
 ;;;###autoload


### PR DESCRIPTION
The icons are not updated after creating a new directory:
![image](https://user-images.githubusercontent.com/1837971/100343318-80337300-2fdf-11eb-8b74-e7d2d8d15a7b.png)

And after renaming a file or directory:
![image](https://user-images.githubusercontent.com/1837971/100343459-ae18b780-2fdf-11eb-9d53-4ff3a7ca85a5.png)

This pr adds the necessary advices to update the icons correctly.
