### PR TITLE
Display icons in find-dired output

### DIFF
--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -34,6 +34,7 @@
 
 (require 'cl-lib)
 (require 'dired)
+(require 'find-dired)
 (require 'all-the-icons)
 
 (defface all-the-icons-dired-dir-face
@@ -107,6 +108,7 @@
     (advice-add 'dired-internal-do-deletions :around #'all-the-icons-dired--refresh-advice)
     (advice-add 'dired-insert-subdir :around #'all-the-icons-dired--refresh-advice)
     (advice-add 'dired-do-kill-lines :around #'all-the-icons-dired--refresh-advice)
+    (advice-add 'find-dired-sentinel :around #'all-the-icons-dired--refresh-advice)
     (with-eval-after-load 'dired-narrow
       (advice-add 'dired-narrow--internal :around #'all-the-icons-dired--refresh-advice))
     (all-the-icons-dired--refresh)))
@@ -119,6 +121,7 @@
   (advice-remove 'dired-narrow--internal #'all-the-icons-dired--refresh-advice)
   (advice-remove 'dired-insert-subdir #'all-the-icons-dired--refresh-advice)
   (advice-remove 'dired-do-kill-lines #'all-the-icons-dired--refresh-advice)
+  (advice-remove 'find-dired-sentinel #'all-the-icons-dired--refresh-advice)
   (all-the-icons-dired--remove-all-overlays))
 
 ;;;###autoload


### PR DESCRIPTION
find-dired is not covered by any of the existing advice, so no refresh will be
triggered.

Since find-dired runs find in a subprocess, we advise the process sentinel
instead of find-dired itself.

Resolves #48