### PR TITLE
Support to customize face of file icon

### DIFF
--- a/all-the-icons-dired.el
+++ b/all-the-icons-dired.el
@@ -42,6 +42,12 @@
   "Face for the directory icon"
   :group 'all-the-icons-faces)
 
+(defface all-the-icons-dired-file-face
+  '((((background dark)) :foreground "white")
+    (((background light)) :foreground "black"))
+  "Face for the f icon"
+  :group 'all-the-icons-faces)
+
 (defcustom all-the-icons-dired-v-adjust 0.01
   "The default vertical adjustment of the icon in the dired buffer."
   :group 'all-the-icons
@@ -86,7 +92,9 @@
                             (all-the-icons-icon-for-dir file
                                                         :face 'all-the-icons-dired-dir-face
                                                         :v-adjust all-the-icons-dired-v-adjust)
-                          (all-the-icons-icon-for-file file :v-adjust all-the-icons-dired-v-adjust))))
+                          (all-the-icons-icon-for-file file
+						       :face 'all-the-icons-dired-file-face
+						       :v-adjust all-the-icons-dired-v-adjust))))
               (if (member file '("." ".."))
                   (all-the-icons-dired--add-overlay (point) "  \t")
                 (all-the-icons-dired--add-overlay (point) (concat icon "\t")))))))


### PR DESCRIPTION
When I try to use this package, I have customized the directory icon face, but the face of file icons is not consistent with it.

![image](https://user-images.githubusercontent.com/63050399/104300819-e7f73c00-5501-11eb-87a8-4c2d666aa830.png)

I have expanded a face named `all-the-icons-dired-file-face`.

Use the following code to customize it.

``` emacs-lisp
(use-package all-the-icons-dired
  :hook (dired-mode-hook . all-the-icons-dired-mode)
  :custom-face
  (all-the-icons-dired-dir-face ((t (:height 0.8))))
  (all-the-icons-dired-file-face ((t (:height 0.8)))))
```

It looks more uniform.

![image](https://user-images.githubusercontent.com/63050399/104301380-884d6080-5502-11eb-908f-32d6031e7f9b.png)
